### PR TITLE
Update the mixin_msg_bot 

### DIFF
--- a/README-russian.md
+++ b/README-russian.md
@@ -220,11 +220,10 @@ def on_message(ws, message):
 
 if __name__ == "__main__":
 
-    mixin_api = MIXIN_API(mixin_config)
-
-    mixin_ws = MIXIN_WS_API(on_message=on_message)
-
-    mixin_ws.run()
+    # mixin_api = MIXIN_API(mixin_config)
+    while True:
+        mixin_ws = MIXIN_WS_API(on_message=on_message)
+        mixin_ws.run()
 ```
 
 Запустите app-mini.py, НЕ ЗАБУДЬТЕ активировать перед этим  "виртуальное окружение" python"
@@ -254,9 +253,10 @@ ws open
 ```python
 if __name__ == "__main__":
 
-    mixin_api = MIXIN_API(mixin_config)
-    mixin_ws = MIXIN_WS_API(on_message=on_message)
-    mixin_ws.run()
+    # mixin_api = MIXIN_API(mixin_config)
+    while True:
+        mixin_ws = MIXIN_WS_API(on_message=on_message)
+        mixin_ws.run()
 ```
 
 Отправьте сообщение операции READ на сервер, чтобы он знал, что сообщение прочитано. Иначе бот получит повторное сообщение, когда он подключится к серверу, если не будет отметки о прочтении.

--- a/README-zhchs.md
+++ b/README-zhchs.md
@@ -228,11 +228,10 @@ def on_message(ws, message):
 
 if __name__ == "__main__":
 
-    mixin_api = MIXIN_API(mixin_config)
-
-    mixin_ws = MIXIN_WS_API(on_message=on_message)
-
-    mixin_ws.run()
+    # mixin_api = MIXIN_API(mixin_config)
+    while True:
+        mixin_ws = MIXIN_WS_API(on_message=on_message)
+        mixin_ws.run()
 ```
 
 运行 app-mini.py, 记得要先激活“虚拟环境”哦!
@@ -260,9 +259,10 @@ WebSocket是建立在TCP基础之上的全双工通讯方式，我们需要建�
 ```python
 if __name__ == "__main__":
 
-    mixin_api = MIXIN_API(mixin_config)
-    mixin_ws = MIXIN_WS_API(on_message=on_message)
-    mixin_ws.run()
+    # mixin_api = MIXIN_API(mixin_config)
+    while True:
+        mixin_ws = MIXIN_WS_API(on_message=on_message)
+        mixin_ws.run()
 ```
 
 每接收到一个消息，需要按消息编号(message_id)给服务器回复一个"已读"的消息,避免服务器在机器人重新登入后，再次发送处理过的消息！

--- a/README.md
+++ b/README.md
@@ -216,11 +216,10 @@ def on_message(ws, message):
 
 if __name__ == "__main__":
 
-    mixin_api = MIXIN_API(mixin_config)
-
-    mixin_ws = MIXIN_WS_API(on_message=on_message)
-
-    mixin_ws.run()
+    # mixin_api = MIXIN_API(mixin_config)
+    while True:
+        mixin_ws = MIXIN_WS_API(on_message=on_message)
+        mixin_ws.run()
 ```
 
 Run the app-mini.py, DO NOT forget active the python "virtual environment" before!"
@@ -250,9 +249,10 @@ The code creates a websocket client.
 ```python
 if __name__ == "__main__":
 
-    mixin_api = MIXIN_API(mixin_config)
-    mixin_ws = MIXIN_WS_API(on_message=on_message)
-    mixin_ws.run()
+    # mixin_api = MIXIN_API(mixin_config)
+    while True:
+        mixin_ws = MIXIN_WS_API(on_message=on_message)
+        mixin_ws.run()
 ```
 
 Send a READ operation message to the server let it knows this message has been read. The bot will receive the duplicated message when the bot connected to server again if bot don't send response.

--- a/app-mini.py
+++ b/app-mini.py
@@ -56,7 +56,7 @@ def on_message(ws, message):
 
 if __name__ == "__main__":
 
-    mixin_api = MIXIN_API(mixin_config)
+    # mixin_api = MIXIN_API(mixin_config)
     while True:
         mixin_ws = MIXIN_WS_API(on_message=on_message)
         mixin_ws.run()


### PR DESCRIPTION
1.  ` mixin_api = MIXIN_API(mixin_config)` is not necessarily needed while running `app-mini.py`. Cause `mixin_ws_api.py` has already imported the `mixin_config`. 
2. Update the tutorials of mixin_msg_bot.
